### PR TITLE
added new attributes to PATCH /shipments

### DIFF
--- a/server/src/shipment/controller.js
+++ b/server/src/shipment/controller.js
@@ -227,9 +227,12 @@ async function editOne(req, res) {
   handler(
     async () => {
       const { sid } = req.params;
-      const { manifest } = req.body;
+      const { manifest, deletedPackingSlips, newPackingSlips } = req.body;
 
-      await Shipment.updateOne(
+      const p_deleted = deletedPackingSlips.map(x => unassignPackingSlipFromShipment(x));
+      const p_added = newPackingSlips.map(x => assignPackingSlipToShipment(x, sid));
+
+      const p_update = Shipment.updateOne(
         { _id: sid },
         {
           $set: {
@@ -237,6 +240,8 @@ async function editOne(req, res) {
           },
         }
       );
+
+      await Promise.all(p_deleted, p_added, p_update);
 
       return [null];
     },
@@ -259,4 +264,17 @@ async function deleteOne(req, res) {
     "deleting shipment",
     res
   );
+}
+
+/**
+ * 
+ * @param {any[]} packingSlipId Id of packing slip to assign
+ * @param {string} shipmentId _id of Shipment to assign to packing slip
+ */
+async function assignPackingSlipToShipment(packingSlipId, shipmentId) {
+  await PackingSlip.updateOne({ _id: packingSlipId }, { $set: { shipment: shipmentId } });
+}
+
+async function unassignPackingSlipFromShipment(packingSlipId) {
+  await PackingSlip.updateOne({ _id: packingSlipId }, { $unset: { shipment: 1 } });
 }


### PR DESCRIPTION
- `newPackingSlips[]`
- `deletedPackingSlips[]`

which are used by new methods

- `assignPackingSlipToShipment()`
- `unassignPackingSlipFromShipment()`

respectively. These are used to "fix" shipping queue after a shipment
edit, if necessary.