### PR TITLE
Fix carrier service validation

### DIFF
--- a/frontend/src/components/CarrierServiceDropdown.jsx
+++ b/frontend/src/components/CarrierServiceDropdown.jsx
@@ -15,10 +15,11 @@ const CarrierServiceDropdown = ({
   canErrorCheck,
   disabled = false,
 }) => {
+  const [localCarrier, setLocalCarrier] = useState(carrier);
   const [hasSelectError, setHasSelectError] = useState(!isCarrierValid(carrier));
 
   useEffect(()=> {
-    setHasSelectError(!isCarrierValid(carrier));
+    setLocalCarrier(carrier)
   }, [carrier]);
 
   return (
@@ -33,12 +34,13 @@ const CarrierServiceDropdown = ({
           required
           error={canErrorCheck && hasSelectError}
           sx={{ width: "100%" }}
-          value={carrier}
+          value={localCarrier}
           onChange={(event) => {
-            setCarrier(event.target.value);
+            setHasSelectError(!isCarrierValid(event.target.value));
+            setLocalCarrier(event.target.value);
           }}
           onBlur={() => {
-            setCarrier(carrier);
+            setCarrier(localCarrier);
           }}
         >
           {CARRIERS.map((carrier) => (

--- a/frontend/src/components/CarrierServiceDropdown.jsx
+++ b/frontend/src/components/CarrierServiceDropdown.jsx
@@ -20,6 +20,7 @@ const CarrierServiceDropdown = ({
 
   useEffect(()=> {
     setLocalCarrier(carrier)
+    setHasSelectError(!isCarrierValid(carrier))
   }, [carrier]);
 
   return (

--- a/frontend/src/components/CarrierServiceDropdown.jsx
+++ b/frontend/src/components/CarrierServiceDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Grid,
   Select,
@@ -15,8 +15,11 @@ const CarrierServiceDropdown = ({
   canErrorCheck,
   disabled = false,
 }) => {
-  const [localCarrier, setLocalCarrier] = useState(carrier);
-  const [hasSelectError, setHasSelectError] = useState(false);
+  const [hasSelectError, setHasSelectError] = useState(!isCarrierValid(carrier));
+
+  useEffect(()=> {
+    setHasSelectError(!isCarrierValid(carrier));
+  }, [carrier]);
 
   return (
     <Grid item xs>
@@ -30,13 +33,12 @@ const CarrierServiceDropdown = ({
           required
           error={canErrorCheck && hasSelectError}
           sx={{ width: "100%" }}
-          value={localCarrier}
+          value={carrier}
           onChange={(event) => {
-            setHasSelectError(!isCarrierValid(event.target.value));
-            setLocalCarrier(event.target.value);
+            setCarrier(event.target.value);
           }}
           onBlur={() => {
-            setCarrier(localCarrier);
+            setCarrier(carrier);
           }}
         >
           {CARRIERS.map((carrier) => (

--- a/frontend/src/create_shipment/CreateShipmentDialog.jsx
+++ b/frontend/src/create_shipment/CreateShipmentDialog.jsx
@@ -70,6 +70,7 @@ const CreateShipmentDialog = ({
 
   const onResetClick = () => {
     setReset(true);
+    setCanErrorCheck(false)
   };
 
   const onBackClick = () => {


### PR DESCRIPTION
This closes #79
Corrected how the validation error text was displayed for the carrier service (the entire form was correctly validating; this was only a user-facing issue).
Also, clicking reset now reverts the carrier service back to default.