### PR TITLE
fixed batchQty & shipQty

### DIFF
--- a/frontend/src/shipping_queue/PackingSlipDropdown.jsx
+++ b/frontend/src/shipping_queue/PackingSlipDropdown.jsx
@@ -29,8 +29,8 @@ const PackingSlipDrowdown = ({ params, packingSlipId, manifest }) => {
                 return {
                   id: e.item._id,
                   part: e.item,
-                  batchQty: e.item.batch,
-                  shipQty: e.item.quantity,
+                  batchQty: e.item.quantity,
+                  shipQty: e.qty,
                 };
               })}
             columns={[


### PR DESCRIPTION
this is probably an issue with the model fields being ambiguously named
but batchQty is meant to be the quantity that was ordered in the batch
and shipQty is the qty of an item that was packed ie. manifest[x].qty